### PR TITLE
Fix QM9 train options paths

### DIFF
--- a/examples/QM9/train_options.yaml
+++ b/examples/QM9/train_options.yaml
@@ -1,8 +1,8 @@
 # PATHS
 additional_functions_file: ./main.py
 output_path: ./
-train_dataset: data/train
-validation_dataset: data/validation
+train_dataset: ./data/train
+validation_dataset: ./data/validation
 
 # OPTIMIZATION OPTIONS
 loss: MeanSquaredError


### PR DESCRIPTION
This PR changes the paths in the QM9 examples to relative paths, matching the configuration in the other framework examples.