### PR TITLE
Package __version__ added to init

### DIFF
--- a/ignnition/__init__.py
+++ b/ignnition/__init__.py
@@ -1,3 +1,4 @@
+from ignnition._version import __version__
 from ignnition.ignnition_model import Ignnition_model
 
 


### PR DESCRIPTION
This bugfix solves a little issue generated when the package switched to the new versioning system. This allows the following (which is similar to other packages):

`In [1]: import ignnition`
`In [2]: ignnition.__version__`
`Out[2]: '1.1.0'`

Whereas previously the following happened:

`In [1]: import ignnition`
`In [2]: ignnition.__version__`
`AttributeError: module 'ignnition' has no attribute '__version__'`
