### PR TITLE
Fix support for custom loss functions

### DIFF
--- a/ignnition/ignnition_model.py
+++ b/ignnition/ignnition_model.py
@@ -66,11 +66,11 @@ class Ignnition_model:
     __process_path(self, path)
         This method takes as input a path and, considering the location of the model directory, converts all the relative path to absolute paths starting from such model_directory
 
-    __get_loss(self, labels, predictions)
-       Function that return the loss obkect from the keras libarary if specified, or looks for a custom loss objective function specified in the module file.
+    __get_loss(self)
+        Obtain model loss either instantiating a tf.keras.losses.Loss object or a custom loss objective function specified in the module file.
 
     __get_metrics(self)
-        Creates all the metrics corresponding to tf.keras objects, or looks for custom metric functions specified in the module file.
+        Obtain model metrics either instantiating tf.keras.metrics.Metric objects or returning custom metric functions specified in the module file.
 
     __get_compiled_model(self, model_info)
         Compiles the tf model with all the corresponding options
@@ -189,6 +189,7 @@ class Ignnition_model:
         return denorm_metric
 
     def __get_metrics(self):
+        """Get metrics instances or functions for the model."""
         metric_names = self.CONFIG['metrics']
         metrics = []
         output_name = self.model_info.get_output_info()

--- a/ignnition/ignnition_model.py
+++ b/ignnition/ignnition_model.py
@@ -144,6 +144,8 @@ class Ignnition_model:
                 print_failure(f"Additional functions file in {additional_path} does not exists.")
             sys.path.insert(1, str(additional_path.resolve().parent))
             self.module = import_module(additional_path.stem)
+        else:
+            self.module = None
 
         self.model_info = self.__create_model()
         self.generator = Generator()


### PR DESCRIPTION
Current use of custom loss functions is not working properly, mainly due to the use of the `tf.py_function` construct together with passing the `gnn_model` as argument.

This PR changes the model loss obtention method to return either the instantiated Tensorflow Loss object or a specific loss function contained in the additional functions module. This mimics the way the metrics are obtained and fixes support for custom loss functions. Additional inputs to the function can be handled by appending them to the `input` keyword in the last readout operation of the `model_description` file. Performance of the loss evaluation can be achieved by making the original loss function a `tf.function` but is left to the user, due to the loss of flexibility.

In addition, other fixes like updated documentation and error handling when the requested custom loss is not found are included.

This changes do not affect performance of current examples, as they all use predefined Keras losses and metrics which work in the same way.