### PR TITLE
Bf unspecified train dataset

### DIFF
--- a/docs/train_and_evaluate.md
+++ b/docs/train_and_evaluate.md
@@ -17,6 +17,11 @@ For this, IGNNITION incorporates a debugging system which is based on producing 
 
     model.computational_graph()
 
+An important consideration is that this functionality requires a valid definition of the train dataset or of the predict dataset. Thus, the user should specify at least one of them in the *train_options.yaml*, just as we show below: 
+
+    # PATHS
+    train_dataset: <PATH TO YOUR DATA>
+    
 This will create a directory named "computational_graph", in the corresponding path indicated in the "train_options.yml" file. We further extend on how to visualize or interpret the output of this operation in [debugging assistant](debugging_assistant.md). 
 
 ### Train and validation

--- a/ignnition/ignnition_model.py
+++ b/ignnition/ignnition_model.py
@@ -806,7 +806,11 @@ class IgnnitionModel:
 
     def computational_graph(self):
         # Check if we can generate the computational graph without a dataset
-        train_path = self.__process_path(self.CONFIG['train_dataset'])
+        try:
+            train_path = self.__process_path(self.CONFIG['train_dataset'])
+        except:
+            print_failure('In order to build the computational graph of your model, you must first specify a valid path for the train dataset in the train_options.yaml file. Please revise that you have done so successfully.')
+
         if not hasattr(self, 'gnn_model'):
             self.__create_gnn(path=train_path)
 

--- a/ignnition/ignnition_model.py
+++ b/ignnition/ignnition_model.py
@@ -806,14 +806,19 @@ class IgnnitionModel:
 
     def computational_graph(self):
         # Check if we can generate the computational graph without a dataset
-        try:
-            train_path = self.__process_path(self.CONFIG['train_dataset'])
-        except:
-            print_failure('In order to build the computational graph of your model, you must first specify a valid path for the train dataset in the train_options.yaml file. Please revise that you have done so successfully.')
+
+        train_path = self.__process_path(self.CONFIG['train_dataset']) if 'train_dataset' in self.CONFIG else ''
+        pred_path = self.__process_path(self.CONFIG['predict_dataset']) if 'predict_dataset' in self.CONFIG else ''
+        data_path = ''
+        if os.path.isdir(train_path):
+            data_path = train_path
+        elif os.path.isdir(pred_path):
+            data_path = pred_path
+        else:
+            print_failure('In order to build the computational graph of your model, you must specify valid path to the train dataset or the predict dataset in the train_options.yaml file. Please revise that you have specified at least one of them, and that they point to a valid dataset.')
 
         if not hasattr(self, 'gnn_model'):
-            self.__create_gnn(path=train_path)
-
+            self.__create_gnn(path=data_path)
         print_header(
             'Generating the computational graph... \n----------------------------------------------------'
             '-----------------------\n')
@@ -828,7 +833,7 @@ class IgnnitionModel:
         tf.summary.trace_on(graph=True, profiler=True)
 
         # evaluate one single input
-        sample_it = self.__input_fn_generator(train_path, training=False, data_samples=None, iterator=True)
+        sample_it = self.__input_fn_generator(data_path, training=False, data_samples=None, iterator=True)
         sample = sample_it.get_next()
         # Call only one tf.function when tracing.
         _ = self.gnn_model(sample, training=False)

--- a/ignnition/utils.py
+++ b/ignnition/utils.py
@@ -64,7 +64,7 @@ def print_info(msg):
        Message to be printed
     """
 
-    tf.print(BColors.FAIL + msg + BColors.ENDC, output_stream=sys.stderr)
+    tf.print(BColors.FAIL + msg + '\n' + BColors.ENDC, output_stream=sys.stderr)
 
 
 def print_header(msg):


### PR DESCRIPTION
This bug fix is to ensure that the computational graph can be built using data samples from either the train or from the predict dataset. If none of them is specified, then an error is triggered. Moreover, the necessary documentation was added.